### PR TITLE
Bugfix & vetor operation

### DIFF
--- a/core.py
+++ b/core.py
@@ -61,6 +61,29 @@ class Vertex:
         if l==0: return self
         return divide(l)
 
+    def __add__(self, other):
+        vector = Vertex(self.x, self.y, self.z)
+        return vector.add(other)
+
+    def __sub__(self, other):
+        vector = Vertex(self.x, self.y, self.z)
+        return vector.subtract(other)
+
+    def __mul__(self, factor):
+        vector = Vertex(self.x, self.y, self.z)
+        return vector.scale(factor)
+
+    # for python 3
+    def __truediv__(self, factor):
+        vector = Vertex(self.x, self.y, self.z)
+        return vector.divide(factor)
+
+    # for python 2
+    def __div__(self, factor):
+        vector = Vertex(self.x, self.y, self.z)
+        return vector.divide(factor)
+
+
 class Face:
     def __init__(self,vertices=None):
         if (vertices==None):

--- a/subdivision.py
+++ b/subdivision.py
@@ -134,7 +134,7 @@ def splitGrid(face,nU,nV):
 def _getVerticesBetween(v1,v2,n):
     row=[]
     deltaV=_vec.subtract(v2,v1)
-    deltaV=_vec.div(deltaV,n)
+    deltaV=_vec.divide(deltaV,n)
     for i in range(n):
         addV=_vec.scale(deltaV,i)
         row.append(_vec.add(addV,v1))


### PR DESCRIPTION
@worbit @demsham @modellstadt @anaanton @gelayoo 

I just fixed a bug in _getVerticesBetween() function which I found while I was playing with this library.

As well as that, I also introduced some basic operators for vector operations. Unless you intentionally  implemented them for educational simplicity, I believe they would be nicer to have.

Corresponding documentation: [9.9. operator — Standard operators as functions](https://docs.python.org/2.7/library/operator.html#operator.__add__)

```
a = Vertex(10, 20, 30)
b = Vertex(5, 10, 15)

a + b # (15 30 45)
a - b # (5 10 15)
a * 2 # (20.0 40.0 60.0)
a / 2 # (5.0 10.0 15.0)
```

They all work at least under my environment. I hope this would be merged without any problems!