### PR TITLE
Acdc21

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,6 @@ from .utils_math import *
 from .utils_mesh import *
 from .utils_poly import *
 from .utils_vertex import *
-from .utils_grid import *
+#from .utils_grid import *
 
 __all__ = [name for name in dir() if not name.startswith('_')]

--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,6 @@ from .utils_math import *
 from .utils_mesh import *
 from .utils_poly import *
 from .utils_vertex import *
-#from .utils_grid import *
+from .utils_grid import *
 
 __all__ = [name for name in dir() if not name.startswith('_')]

--- a/colab3D.py
+++ b/colab3D.py
@@ -25,7 +25,7 @@ __canvasHeight = "56.25vw"
 
 __positionsWelded = []
 
-def display_mesh(mesh,canvasWidth=None,canvasHeight=None,showAxis=True,showEdges=False,edgesWidth=1.0,showWireframe=False,showPointsCloud=False,showPointsNumbers=False,backgroundColor=(0,0,0),edgesColor=(1,1,1,1),pointColor=(1,1,1),pointSize=10,numberColor=(1,1,1),numberSize=1):
+def display_mesh(mesh,canvasWidth=None,canvasHeight=None,showAxis=True,showEdges=False,edgesWidth=1.0,showWireframe=False,showPointsCloud=False,showPointsNumbers=False,backgroundColor=(0,0,0),edgesColor=(1,1,1,1),pointColor=(1,1,1),pointSize=10,numberColor=(1,1,1),numberSize=1, significant_digits = 3):
   """
   Displays Mesh.
   Arguments:
@@ -135,7 +135,8 @@ def display_faces(faces):
     cIndex=0
     for face in faces:
         for v in face.vertices:
-            positions.extend((v.x,v.y,v.z))
+
+            positions.extend(round(v.x,significant_digits),round(v.y,significant_digits),round(v.z,significant_digits))
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
         if len(face.vertices)>3:

--- a/colab3D.py
+++ b/colab3D.py
@@ -26,7 +26,7 @@ __canvasHeight = "56.25vw"
 __positionsWelded = []
 
 
-def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=3):
+def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=2, mode="unwelded"):
     """
     Displays Mesh.
     Arguments:
@@ -54,6 +54,10 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
     numberColor : tuple (r,g,b)
                   r,g,b values, 0.0 to 1.0
     numberSize : float
+    significant_digits: interger
+                precision 0 to 15
+    mode : string
+                values "welded" or "unwelded"
     """
     global __canvasWidth, __canvasHeight, __showAxis, __showEdges, __edgesWidth, __showWireframe, __showPointsCloud, __showPointsNumbers, __backgroundColor, __edgesColor, __pointColor, __pointSize, __numberColor, __numberSize
     if(canvasWidth):
@@ -73,13 +77,23 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
     __numberColor = numberColor
     __numberSize = numberSize
 
+    mesh.update_topology()
+
+    for v in mesh.vertices:
+        v.x = round(v.x, 2)
+        v.y = round(v.y, 2)
+        v.z = round(v.z, 2)
+
     if(showPointsNumbers):
         global __positionsWelded
         __positionsWelded = []
         for v in mesh.vertices:
-            __positionsWelded.extend((v.x, v.y, v.z))
+            __positionsWelded.extend(v.x, v.y, v.z)
 
-    return display_faces(mesh.faces, significant_digits)
+    if mode == "unwelded":
+        return display_faces(mesh.faces)
+    elif mode == "welded":
+        return display_faces_welded(mesh.faces)
 
 
 def display_faces_welded(faces):
@@ -134,9 +148,7 @@ def display_faces(faces, significant_digits=3):
 
     for face in faces:
         for v in face.vertices:
-
-            positions.extend((round(v.x, significant_digits), round(
-                v.y, significant_digits), round(v.z, significant_digits)))
+            positions.extend(v.x, v.y, v.z)
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
         if len(face.vertices) > 3:

--- a/colab3D.py
+++ b/colab3D.py
@@ -99,8 +99,7 @@ def display_faces_welded(faces, significant_digits=2):
         # triangle
         for i in range(3):
             p = face.vertices[i]
-            ptuple = (round(p.x, significant_digits), round(
-                p.y, significant_digits), round(p.z, significant_digits))
+            ptuple = (p.x, p.y, p.z)
             if ptuple in verticesDict:
                 indices.append(verticesDict[ptuple])
             else:
@@ -112,8 +111,7 @@ def display_faces_welded(faces, significant_digits=2):
         # quad
         if len(face.vertices) > 3:
             p = face.vertices[3]
-            ptuple = (round(p.x, significant_digits), round(
-                p.y, significant_digits), round(p.z, significant_digits))
+            ptuple = (p.x, p.y, p.z)
             i0 = indices[-3]
             i1 = indices[-1]
             indices.append(i0)
@@ -126,6 +124,9 @@ def display_faces_welded(faces, significant_digits=2):
                 colors.extend(face.color)
                 indices.append(cIndex)
                 cIndex += 1
+
+    positions = [tuple([round(x, significant_digits) for x in pos]) for pos in positions]
+
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code

--- a/colab3D.py
+++ b/colab3D.py
@@ -125,7 +125,7 @@ def display_faces_welded(faces, significant_digits=2):
                 indices.append(cIndex)
                 cIndex += 1
 
-    positions = [round(p, significant_digits) for p in positions]
+    #positions = [round(p, significant_digits) for p in positions]
 
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()

--- a/colab3D.py
+++ b/colab3D.py
@@ -124,9 +124,7 @@ def display_faces_welded(faces, significant_digits=2):
                 colors.extend(face.color)
                 indices.append(cIndex)
                 cIndex += 1
-
-    positions = [tuple([round(x, significant_digits) for x in pos]) for pos in positions]
-
+    print(positions)
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code

--- a/colab3D.py
+++ b/colab3D.py
@@ -124,7 +124,9 @@ def display_faces_welded(faces, significant_digits=2):
                 colors.extend(face.color)
                 indices.append(cIndex)
                 cIndex += 1
-    print(positions)
+
+    positions = [round(p, significant_digits) for p in positions]
+
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code

--- a/colab3D.py
+++ b/colab3D.py
@@ -26,7 +26,7 @@ __canvasHeight = "56.25vw"
 __positionsWelded = []
 
 
-def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=2, mode="unwelded"):
+def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=2, welded=True):
     """
     Displays Mesh.
     Arguments:
@@ -54,10 +54,8 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
     numberColor : tuple (r,g,b)
                   r,g,b values, 0.0 to 1.0
     numberSize : float
-    significant_digits: interger
-                precision 0 to 15
-    mode : string
-                values "welded" or "unwelded"
+    significant_digits: integer
+    welded : Boolean
     """
     global __canvasWidth, __canvasHeight, __showAxis, __showEdges, __edgesWidth, __showWireframe, __showPointsCloud, __showPointsNumbers, __backgroundColor, __edgesColor, __pointColor, __pointSize, __numberColor, __numberSize
     if(canvasWidth):
@@ -77,26 +75,20 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
     __numberColor = numberColor
     __numberSize = numberSize
 
-    mesh.update_topology()
-
-    for v in mesh.vertices:
-        v.x = round(v.x, significant_digits)
-        v.y = round(v.y, significant_digits)
-        v.z = round(v.z, significant_digits)
-
     if(showPointsNumbers):
         global __positionsWelded
         __positionsWelded = []
         for v in mesh.vertices:
-            __positionsWelded.extend(v.x, v.y, v.z)
+            __positionsWelded.extend((round(v.x, significant_digits), round(
+                v.y, significant_digits), round(v.z, significant_digits)))
 
-    if mode == "unwelded":
-        return display_faces(mesh.faces)
-    elif mode == "welded":
-        return display_faces_welded(mesh.faces)
+    if welded:
+        display_faces_welded(mesh.faces, significant_digits)
+    else:
+        return display_faces(mesh.faces, significant_digits)
 
 
-def display_faces_welded(faces):
+def display_faces_welded(faces, significant_digits=2):
     __begin3D()
     verticesDict = {}
     positions = []
@@ -104,11 +96,11 @@ def display_faces_welded(faces):
     colors = []
     cIndex = 0
     for face in faces:
-        col = face.color
         # triangle
         for i in range(3):
             p = face.vertices[i]
-            ptuple = (p.x, p.y, p.z)
+            ptuple = (round(p.x, significant_digits), round(
+                p.y, significant_digits), round(p.z, significant_digits))
             if ptuple in verticesDict:
                 indices.append(verticesDict[ptuple])
             else:
@@ -120,7 +112,8 @@ def display_faces_welded(faces):
         # quad
         if len(face.vertices) > 3:
             p = face.vertices[3]
-            ptuple = (p.x, p.y, p.z)
+            ptuple = (round(p.x, significant_digits), round(
+                p.y, significant_digits), round(p.z, significant_digits))
             i0 = indices[-3]
             i1 = indices[-1]
             indices.append(i0)
@@ -138,7 +131,7 @@ def display_faces_welded(faces):
     return __code
 
 
-def display_faces(faces, significant_digits=3):
+def display_faces(faces, significant_digits=2):
     __begin3D()
     positions = []
     indices = []
@@ -148,7 +141,8 @@ def display_faces(faces, significant_digits=3):
 
     for face in faces:
         for v in face.vertices:
-            positions.extend((v.x, v.y, v.z))
+            positions.extend((round(v.x, significant_digits), round(
+                v.y, significant_digits), round(v.z, significant_digits)))
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
         if len(face.vertices) > 3:

--- a/colab3D.py
+++ b/colab3D.py
@@ -83,7 +83,7 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
                 v.y, significant_digits), round(v.z, significant_digits)))
 
     if welded is True:
-        display_faces_welded(mesh.faces, significant_digits)
+        return display_faces_welded(mesh.faces, significant_digits)
     else:
         return display_faces(mesh.faces, significant_digits)
 
@@ -125,6 +125,8 @@ def display_faces_welded(faces, significant_digits=2):
                 colors.extend(face.color)
                 indices.append(cIndex)
                 cIndex += 1
+
+    positions = [round(p, significant_digits) for p in positions]          
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code

--- a/colab3D.py
+++ b/colab3D.py
@@ -135,8 +135,8 @@ def display_faces(faces, significant_digits=3):
     for face in faces:
         for v in face.vertices:
 
-            positions.extend(round(v.x, 3), round(
-                v.y, 3), round(v.z, 3))
+            positions.extend((round(v.x, significant_digits), round(
+                v.y, significant_digits), round(v.z, significant_digits)))
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
         if len(face.vertices) > 3:

--- a/colab3D.py
+++ b/colab3D.py
@@ -82,13 +82,13 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
             __positionsWelded.extend((round(v.x, significant_digits), round(
                 v.y, significant_digits), round(v.z, significant_digits)))
 
-    if welded:
+    if welded is True:
         display_faces_welded(mesh.faces, significant_digits)
     else:
         return display_faces(mesh.faces, significant_digits)
 
 
-def display_faces_welded(faces, significant_digits=2):
+def display_faces_welded(faces):
     __begin3D()
     verticesDict = {}
     positions = []
@@ -96,6 +96,7 @@ def display_faces_welded(faces, significant_digits=2):
     colors = []
     cIndex = 0
     for face in faces:
+        col = face.color
         # triangle
         for i in range(3):
             p = face.vertices[i]
@@ -124,9 +125,6 @@ def display_faces_welded(faces, significant_digits=2):
                 colors.extend(face.color)
                 indices.append(cIndex)
                 cIndex += 1
-
-    #positions = [round(p, significant_digits) for p in positions]
-
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code

--- a/colab3D.py
+++ b/colab3D.py
@@ -80,9 +80,9 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
     mesh.update_topology()
 
     for v in mesh.vertices:
-        v.x = round(v.x, 2)
-        v.y = round(v.y, 2)
-        v.z = round(v.z, 2)
+        v.x = round(v.x, significant_digits)
+        v.y = round(v.y, significant_digits)
+        v.z = round(v.z, significant_digits)
 
     if(showPointsNumbers):
         global __positionsWelded

--- a/colab3D.py
+++ b/colab3D.py
@@ -1,157 +1,158 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__author__     = ['Benjamin Dillenburger','Demetris Shammas','Mathias Bernhard']
-__copyright__  = 'Copyright 2019 / Digital Building Technologies DBT / ETH Zurich'
-__license__    = 'MIT License'
-__email__      = ['<dbt@arch.ethz.ch>']
+__author__ = ['Benjamin Dillenburger', 'Demetris Shammas', 'Mathias Bernhard']
+__copyright__ = 'Copyright 2019 / Digital Building Technologies DBT / ETH Zurich'
+__license__ = 'MIT License'
+__email__ = ['<dbt@arch.ethz.ch>']
 
-__code=""
+__code = ""
 
 '''display variables'''
-__showAxis=True
-__showEdges=False
-__edgesWidth=1.0
-__showWireframe=False
-__showPointsCloud=False
-__showPointsNumbers=False
-__backgroundColor = (0,0,0)
-__edgesColor = (1,1,1,1)
-__pointColor = (1,1,1)
+__showAxis = True
+__showEdges = False
+__edgesWidth = 1.0
+__showWireframe = False
+__showPointsCloud = False
+__showPointsNumbers = False
+__backgroundColor = (0, 0, 0)
+__edgesColor = (1, 1, 1, 1)
+__pointColor = (1, 1, 1)
 __pointSize = 10
-__numberColor = (1,1,1)
+__numberColor = (1, 1, 1)
 __numberSize = 1
 __canvasWidth = "100%"
 __canvasHeight = "56.25vw"
 
 __positionsWelded = []
 
-def display_mesh(mesh,canvasWidth=None,canvasHeight=None,showAxis=True,showEdges=False,edgesWidth=1.0,showWireframe=False,showPointsCloud=False,showPointsNumbers=False,backgroundColor=(0,0,0),edgesColor=(1,1,1,1),pointColor=(1,1,1),pointSize=10,numberColor=(1,1,1),numberSize=1, significant_digits = 3):
-  """
-  Displays Mesh.
-  Arguments:
-  ----------
-  mesh : mola.core.Mesh
-         The mesh to be displayed
 
-  Optional Arguments:
-  ----------
-  canvasWidth : float
-  canvasHeight : float
-  showAxis : Boolean
-  showEdges : Boolean
-  showWireframe : Boolean
-  showPointsCloud : Boolean
-  showPointsNumbers : Boolean
-  edgesWidth : float
-  backgroundColor : tuple (r,g,b)
-                    r,g,b values, 0.0 to 1.0
-  edgesColor : tuple (r,g,b,a)
-              r,g,b,a values, 0.0 to 1.0
-  pointColor : tuple (r,g,b)
-                r,g,b values, 0.0 to 1.0
-  pointSize : float
-  numberColor : tuple (r,g,b)
-                r,g,b values, 0.0 to 1.0
-  numberSize : float
-  """
-  global __canvasWidth, __canvasHeight, __showAxis,__showEdges,__edgesWidth,__showWireframe,__showPointsCloud,__showPointsNumbers,__backgroundColor,__edgesColor,__pointColor,__pointSize,__numberColor,__numberSize
-  if(canvasWidth):
-    __canvasWidth = str(canvasWidth) + "px"
-  if(canvasHeight):
-    __canvasHeight = str(canvasHeight) + "px"
-  __showAxis=showAxis
-  __showEdges=showEdges
-  __edgesWidth=edgesWidth
-  __showWireframe=showWireframe
-  __showPointsCloud = showPointsCloud
-  __showPointsNumbers = showPointsNumbers
-  __backgroundColor = backgroundColor
-  __edgesColor = edgesColor
-  __pointColor = pointColor
-  __pointSize = pointSize
-  __numberColor = numberColor
-  __numberSize = numberSize
+def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=3):
+    """
+    Displays Mesh.
+    Arguments:
+    ----------
+    mesh : mola.core.Mesh
+           The mesh to be displayed
 
-  if(showPointsNumbers):
-    global __positionsWelded
-    __positionsWelded = []
-    for v in mesh.vertices:
-      __positionsWelded.extend((v.x,v.y,v.z))
+    Optional Arguments:
+    ----------
+    canvasWidth : float
+    canvasHeight : float
+    showAxis : Boolean
+    showEdges : Boolean
+    showWireframe : Boolean
+    showPointsCloud : Boolean
+    showPointsNumbers : Boolean
+    edgesWidth : float
+    backgroundColor : tuple (r,g,b)
+                      r,g,b values, 0.0 to 1.0
+    edgesColor : tuple (r,g,b,a)
+                r,g,b,a values, 0.0 to 1.0
+    pointColor : tuple (r,g,b)
+                  r,g,b values, 0.0 to 1.0
+    pointSize : float
+    numberColor : tuple (r,g,b)
+                  r,g,b values, 0.0 to 1.0
+    numberSize : float
+    """
+    global __canvasWidth, __canvasHeight, __showAxis, __showEdges, __edgesWidth, __showWireframe, __showPointsCloud, __showPointsNumbers, __backgroundColor, __edgesColor, __pointColor, __pointSize, __numberColor, __numberSize
+    if(canvasWidth):
+        __canvasWidth = str(canvasWidth) + "px"
+    if(canvasHeight):
+        __canvasHeight = str(canvasHeight) + "px"
+    __showAxis = showAxis
+    __showEdges = showEdges
+    __edgesWidth = edgesWidth
+    __showWireframe = showWireframe
+    __showPointsCloud = showPointsCloud
+    __showPointsNumbers = showPointsNumbers
+    __backgroundColor = backgroundColor
+    __edgesColor = edgesColor
+    __pointColor = pointColor
+    __pointSize = pointSize
+    __numberColor = numberColor
+    __numberSize = numberSize
 
-  return display_faces(mesh.faces, significant_digits)
+    if(showPointsNumbers):
+        global __positionsWelded
+        __positionsWelded = []
+        for v in mesh.vertices:
+            __positionsWelded.extend((v.x, v.y, v.z))
 
+    return display_faces(mesh.faces, significant_digits)
 
 
 def display_faces_welded(faces):
     __begin3D()
-    verticesDict={}
-    positions=[]
-    indices=[]
-    colors=[]
-    cIndex=0
+    verticesDict = {}
+    positions = []
+    indices = []
+    colors = []
+    cIndex = 0
     for face in faces:
-        col=face.color
+        col = face.color
         # triangle
         for i in range(3):
-            p=face.vertices[i]
-            ptuple = (p.x,p.y,p.z)
+            p = face.vertices[i]
+            ptuple = (p.x, p.y, p.z)
             if ptuple in verticesDict:
                 indices.append(verticesDict[ptuple])
             else:
-                verticesDict[ptuple]=cIndex
+                verticesDict[ptuple] = cIndex
                 positions.extend(ptuple)
                 colors.extend(face.color)
                 indices.append(cIndex)
-                cIndex+=1
+                cIndex += 1
         # quad
-        if len(face.vertices)>3:
-            p=face.vertices[3]
-            ptuple = (p.x,p.y,p.z)
-            i0=indices[-3]
-            i1=indices[-1]
+        if len(face.vertices) > 3:
+            p = face.vertices[3]
+            ptuple = (p.x, p.y, p.z)
+            i0 = indices[-3]
+            i1 = indices[-1]
             indices.append(i0)
             indices.append(i1)
             if ptuple in verticesDict:
                 indices.append(verticesDict[ptuple])
             else:
-                verticesDict[ptuple]=cIndex
+                verticesDict[ptuple] = cIndex
                 positions.extend(ptuple)
                 colors.extend(face.color)
                 indices.append(cIndex)
-                cIndex+=1
+                cIndex += 1
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code
 
 
-
-
-def display_faces(faces, significant_digits = 3):
+def display_faces(faces, significant_digits=3):
     __begin3D()
-    positions=[]
-    indices=[]
-    colors=[]
+    positions = []
+    indices = []
+    colors = []
 
-    cIndex=0
+    cIndex = 0
+    significant_digits = 3
     for face in faces:
         for v in face.vertices:
 
-            positions.extend(round(v.x,significant_digits),round(v.y,significant_digits),round(v.z,significant_digits))
+            positions.extend(round(v.x, significant_digits), round(
+                v.y, significant_digits), round(v.z, significant_digits))
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
-        if len(face.vertices)>3:
+        if len(face.vertices) > 3:
             # indices.extend([cIndex+2, cIndex+3, cIndex])
-            for i in range(2,len(face.vertices)-1):
+            for i in range(2, len(face.vertices)-1):
                 indices.extend([cIndex+i, cIndex+i+1, cIndex])
-        cIndex+=len(face.vertices)
+        cIndex += len(face.vertices)
     __draw_mesh_with_colors(positions, indices, colors)
     __end3D()
     return __code
 
+
 def __begin3D():
     global __code
-    __code=""
-    __code+='''<canvas id="renderCanvas" touch-action="none"></canvas>
+    __code = ""
+    __code += '''<canvas id="renderCanvas" touch-action="none"></canvas>
         <script src="https://cdn.babylonjs.com/babylon.js"></script>
         <style>
             html, body {
@@ -169,23 +170,25 @@ def __begin3D():
         </style>
         <script>
       var canvas = document.getElementById("renderCanvas");'''
-    __code+='''var createScene = function () {var scene = new BABYLON.Scene(engine);'''
-    __code+='''scene.useRightHandedSystem = true;'''
-    __code+='''scene.clearColor = new BABYLON.Color3'''+str(__backgroundColor)+ ";"
-    __code+='''var light = new BABYLON.DirectionalLight("direct", new BABYLON.Vector3(1, 1, 1), scene);var light2 = new BABYLON.DirectionalLight("direct", new BABYLON.Vector3(-1, -1, -1), scene);'''
-    __code+='''var camera = new BABYLON.ArcRotateCamera("camera1",  0, 0, 0, new BABYLON.Vector3(0, 0, 0), scene);
+    __code += '''var createScene = function () {var scene = new BABYLON.Scene(engine);'''
+    __code += '''scene.useRightHandedSystem = true;'''
+    __code += '''scene.clearColor = new BABYLON.Color3''' + \
+        str(__backgroundColor) + ";"
+    __code += '''var light = new BABYLON.DirectionalLight("direct", new BABYLON.Vector3(1, 1, 1), scene);var light2 = new BABYLON.DirectionalLight("direct", new BABYLON.Vector3(-1, -1, -1), scene);'''
+    __code += '''var camera = new BABYLON.ArcRotateCamera("camera1",  0, 0, 0, new BABYLON.Vector3(0, 0, 0), scene);
             camera.setPosition(new BABYLON.Vector3(0, 5, 30));
              camera.attachControl(canvas, true);'''
-    __code+=''' var light = new BABYLON.HemisphericLight("light1", new BABYLON.Vector3(0, 1, 0), scene);
+    __code += ''' var light = new BABYLON.HemisphericLight("light1", new BABYLON.Vector3(0, 1, 0), scene);
     light.intensity = 0.5;'''
 
 
-def __draw_mesh_with_colors(vertices,faces,vertexColors):
+def __draw_mesh_with_colors(vertices, faces, vertexColors):
     global __code
-    __code+="var positions = "+str(vertices)+";"
-    __code+="var indices = "+str(faces)+";"
-    __code+="var colors = "+str(vertexColors)+";"
+    __code += "var positions = "+str(vertices)+";"
+    __code += "var indices = "+str(faces)+";"
+    __code += "var colors = "+str(vertexColors)+";"
     return __code
+
 
 """
 def __draw_test_mesh():
@@ -193,9 +196,11 @@ def __draw_test_mesh():
     __code+='''    var positions = [-5, 2, -3, -7, -2, -3, -3, -2, -3, 5, 2, 3, 7, -2, 3, 3, -2, 3];
             var indices = [0, 1, 2, 3, 4, 5];    '''
 """
+
+
 def __end3D():
-  global __code
-  __code+= '''
+    global __code
+    __code += '''
         //Create a custom mesh
           var customMesh = new BABYLON.Mesh("custom", scene);
         //Empty array to contain calculated values
@@ -211,44 +216,47 @@ def __end3D():
           vertexData.applyToMesh(customMesh);
           var mat = new BABYLON.StandardMaterial("mat", scene);
           mat.backFaceCulling = false;'''
-  if __showWireframe:
-    __code+='''mat.wireframe=true;'''
-  if __showPointsCloud:
-    __code+='''mat.pointsCloud=true;'''
-    __code+='''mat.pointSize=''' + str(__pointSize) + ';'
-    __code+='''mat.diffuseColor = new BABYLON.Color3'''+str(__pointColor)+ ';'
-    __code+='''mat.emissiveColor = new BABYLON.Color3'''+str(__pointColor)+ ';'
-    __code+='''mat.disableLighting = true; '''
-  if __showEdges:
-    __code+= '''customMesh.enableEdgesRendering();'''
-    __code+= '''customMesh.edgesWidth = ''' + str(__edgesWidth * 10) +';'
-    __code+= '''customMesh.edgesColor = new BABYLON.Color4'''+str(__edgesColor)+ ';'
-  if __showPointsNumbers:
-    __code+='''
+    if __showWireframe:
+        __code += '''mat.wireframe=true;'''
+    if __showPointsCloud:
+        __code += '''mat.pointsCloud=true;'''
+        __code += '''mat.pointSize=''' + str(__pointSize) + ';'
+        __code += '''mat.diffuseColor = new BABYLON.Color3''' + \
+            str(__pointColor) + ';'
+        __code += '''mat.emissiveColor = new BABYLON.Color3''' + \
+            str(__pointColor) + ';'
+        __code += '''mat.disableLighting = true; '''
+    if __showEdges:
+        __code += '''customMesh.enableEdgesRendering();'''
+        __code += '''customMesh.edgesWidth = ''' + str(__edgesWidth * 10) + ';'
+        __code += '''customMesh.edgesColor = new BABYLON.Color4''' + \
+            str(__edgesColor) + ';'
+    if __showPointsNumbers:
+        __code += '''
     var drawNumber = function(scene, text, posVector){
       //data reporter
       var outputplane = BABYLON.Mesh.CreatePlane("outputplane", 1.5, scene, false);
       outputplane.billboardMode = BABYLON.AbstractMesh.BILLBOARDMODE_ALL;
       outputplane.material = new BABYLON.StandardMaterial("outputplane", scene);
       outputplane.position = posVector;
-      outputplane.scaling.x = '''+str(__numberSize)+ ''';
-      outputplane.scaling.y = '''+str(__numberSize)+ ''';
+      outputplane.scaling.x = '''+str(__numberSize) + ''';
+      outputplane.scaling.y = '''+str(__numberSize) + ''';
       var outputplaneTexture = new BABYLON.DynamicTexture("dynamic texture", 512, scene, true);
       outputplane.material.diffuseTexture = outputplaneTexture;
-      outputplane.material.diffuseColor = new BABYLON.Color3'''+str(__numberColor)+ ''';
-      outputplane.material.emissiveColor = new BABYLON.Color3'''+str(__numberColor)+ ''';
+      outputplane.material.diffuseColor = new BABYLON.Color3'''+str(__numberColor) + ''';
+      outputplane.material.emissiveColor = new BABYLON.Color3'''+str(__numberColor) + ''';
       outputplane.material.backFaceCulling = false;
       //outputplaneTexture.getContext().clearRect(0, 140, 512, 512);
       var textColor = new BABYLON.Color3''' + str(__numberColor) + '''.toHexString();
       outputplaneTexture.drawText(text, null, 300, "200px arial", textColor);
       outputplaneTexture.hasAlpha = true;
     };'''
-    __code+='''
+        __code += '''
     //drawNumber(scene,"NT",new BABYLON.Vector3(0,0,0));
     //var vPositions = customMesh.getVerticesData(BABYLON.VertexBuffer.PositionKind);
     //console.log("vplength " + vPositions.length);
     var ind = 0;
-    var pWelded = ''' +str(__positionsWelded)+ ''';
+    var pWelded = ''' + str(__positionsWelded) + ''';
     for(var i=0;i<pWelded.length;i+=3){
       var posX = (pWelded[i]);
       var posY = (pWelded[i+1]);
@@ -257,8 +265,8 @@ def __end3D():
       ind++;
     }
     '''
-  if __showAxis:
-    __code+='''
+    if __showAxis:
+        __code += '''
              var makeTextPlane = function(text, color, size) {
                  var dynamicTexture = new BABYLON.DynamicTexture("DynamicTexture", 50, scene, true);
                  dynamicTexture.hasAlpha = true;
@@ -270,7 +278,7 @@ def __end3D():
                  plane.material.diffuseTexture = dynamicTexture;
                  return plane;
              };'''
-    __code+='''// show axis
+        __code += '''// show axis
             var showAxis = function(size) {
               var axisX = BABYLON.Mesh.CreateLines("axisX", [
                     new BABYLON.Vector3.Zero(), new BABYLON.Vector3(size, 0, 0), new BABYLON.Vector3(size * 0.95, 0.05 * size, 0),
@@ -295,8 +303,8 @@ def __end3D():
               zChar.position = new BABYLON.Vector3(0, 0.05 * size, 0.9 * size);
           };
           showAxis(10);'''
-  __code+='''customMesh.material = mat;'''
-  __code+='''return scene;
+    __code += '''customMesh.material = mat;'''
+    __code += '''return scene;
     };
       var engine = new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });
       var scene = createScene();

--- a/colab3D.py
+++ b/colab3D.py
@@ -26,7 +26,7 @@ __canvasHeight = "56.25vw"
 __positionsWelded = []
 
 
-def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=2, welded=True):
+def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showEdges=False, edgesWidth=1.0, showWireframe=False, showPointsCloud=False, showPointsNumbers=False, backgroundColor=(0, 0, 0), edgesColor=(1, 1, 1, 1), pointColor=(1, 1, 1), pointSize=10, numberColor=(1, 1, 1), numberSize=1, significant_digits=2, welded=False):
     """
     Displays Mesh.
     Arguments:

--- a/colab3D.py
+++ b/colab3D.py
@@ -78,7 +78,7 @@ def display_mesh(mesh,canvasWidth=None,canvasHeight=None,showAxis=True,showEdges
     for v in mesh.vertices:
       __positionsWelded.extend((v.x,v.y,v.z))
 
-  return display_faces(mesh.faces)
+  return display_faces(mesh.faces, significant_digits)
 
 
 
@@ -126,7 +126,7 @@ def display_faces_welded(faces):
 
 
 
-def display_faces(faces):
+def display_faces(faces, significant_digits = 3):
     __begin3D()
     positions=[]
     indices=[]

--- a/colab3D.py
+++ b/colab3D.py
@@ -148,7 +148,7 @@ def display_faces(faces, significant_digits=3):
 
     for face in faces:
         for v in face.vertices:
-            positions.extend(v.x, v.y, v.z)
+            positions.extend((v.x, v.y, v.z))
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
         if len(face.vertices) > 3:

--- a/colab3D.py
+++ b/colab3D.py
@@ -88,7 +88,7 @@ def display_mesh(mesh, canvasWidth=None, canvasHeight=None, showAxis=True, showE
         return display_faces(mesh.faces, significant_digits)
 
 
-def display_faces_welded(faces):
+def display_faces_welded(faces, significant_digits=2):
     __begin3D()
     verticesDict = {}
     positions = []

--- a/colab3D.py
+++ b/colab3D.py
@@ -131,12 +131,12 @@ def display_faces(faces, significant_digits=3):
     colors = []
 
     cIndex = 0
-    significant_digits = 3
+
     for face in faces:
         for v in face.vertices:
 
-            positions.extend(round(v.x, significant_digits), round(
-                v.y, significant_digits), round(v.z, significant_digits))
+            positions.extend(round(v.x, 3), round(
+                v.y, 3), round(v.z, 3))
             colors.extend(face.color)
         indices.extend([cIndex, cIndex+1, cIndex+2])
         if len(face.vertices) > 3:

--- a/mesh_factory.py
+++ b/mesh_factory.py
@@ -169,9 +169,9 @@ def construct_sphere(radius=1, cx=0,cy=0,cz=0,u_res=10,v_res=10):
 
   mesh = Mesh()
   for v in range(v_res+1):
-    theta = math.pi * (v / v_res)
+    theta = math.pi * (float(v) / v_res)
     for u in range(u_res):
-      phi = 2.0 * math.pi * (u / u_res)
+      phi = 2.0 * math.pi * (float(u) / u_res)
       cartesian = _polar_to_cartesian(radius,theta,phi)
       mesh.add_vertex(cartesian[0]+cx,cartesian[1]+cy,cartesian[2]+cz)
 

--- a/module_rhino.py
+++ b/module_rhino.py
@@ -21,7 +21,8 @@ def mesh_from_rhino_mesh(obj):
     return mesh
 
 def display_mesh(mesh):
-    display_faces(mesh.faces)
+
+    return display_faces(mesh.faces)
 
 #todo: method to turn rhino mesh into molamesh
 
@@ -36,6 +37,4 @@ def display_faces(faces):
             vertices.append((v.x,v.y,v.z))
             vertexColors.append((f.color[0]*255,f.color[1]*255,f.color[2]*255))
         facesIndices.append(faceIndices)
-    a = rs.AddMesh(vertices,facesIndices,None,None,vertexColors)
-
-    return a
+    return rs.AddMesh(vertices,facesIndices,None,None,vertexColors)

--- a/module_rhino.py
+++ b/module_rhino.py
@@ -26,16 +26,48 @@ def display_mesh(mesh):
 #todo: method to turn rhino mesh into molamesh
 
 def display_faces(faces):
-    vertices=[]
-    facesIndices=[]
-    vertexColors=[]
+    vertices = []
+    vertexColors = []
+    facesIndices = []
+
     for f in faces:
-        faceIndices=[]
+        faceIndices = []
+        # add vertices
         for v in f.vertices:
             faceIndices.append(len(vertices))
             vertices.append((v.x,v.y,v.z))
             vertexColors.append((f.color[0]*255,f.color[1]*255,f.color[2]*255))
-        facesIndices.append(faceIndices)
+            
+        p = len(f.vertices)
+        if p <= 4:
+            # add one face if it is tri or quad
+            facesIndices.append(faceIndices)
+  
+        else:
+            # add multiple faces if it is ngon  
+            points = [(v.x, v.y, v.z) for v in f.vertices]
+            center_pt = centroid_points(points)
+            c_index = len(vertices)
+            vertices.append(center_pt)
+            vertexColors.append((f.color[0]*255,f.color[1]*255,f.color[2]*255))
+
+            faces = [[a, b, c_index] for a, b in pairwise(faceIndices + faceIndices[0:1])]
+            facesIndices.extend(faces)
+
     a = rs.AddMesh(vertices,facesIndices,None,None,vertexColors)
 
     return a
+
+
+def centroid_points(points):
+    p = len(points)
+    x, y, z = zip(*points)
+
+    return [sum(x) / p, sum(y) / p, sum(z) / p]
+
+
+def pairwise(iterable):
+    a = iterable[:-1]
+    b = iterable[1:]
+
+    return zip(a, b)

--- a/module_rhino.py
+++ b/module_rhino.py
@@ -36,4 +36,6 @@ def display_faces(faces):
             vertices.append((v.x,v.y,v.z))
             vertexColors.append((f.color[0]*255,f.color[1]*255,f.color[2]*255))
         facesIndices.append(faceIndices)
-    rs.AddMesh(vertices,facesIndices,None,None,vertexColors)
+    a = rs.AddMesh(vertices,facesIndices,None,None,vertexColors)
+
+    return a

--- a/utils_grid.py
+++ b/utils_grid.py
@@ -8,7 +8,10 @@ __email__      = ['<dbt@arch.ethz.ch>']
 import math
 from mola import utils_math
 from mola.core_mesh import Mesh
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 def grid_set_values_at_borders(grid, value):
     for i in range(grid.nx):


### PR DESCRIPTION
a few changes in colab 3d and rhino mudules have been made by @eleniv3d and me during the course

in colab3d :  added two arguments to the display_mesh() function called for now significant_digits = 2 and welded = False. (Those being the default values) If you specify welded = True, you would display_faces_welded() and then you can easily have more than 200K faces. In any case both arguments only change the display and not the mesh you export.

in rhino_module: added a return to display_mesh() and display_faces(), this way it can work fo both rhino and grasshopper

in utils_grid, added try and exception when it imports numpy

in mesh_factory: fixed the bug caused by integer subdivision in ironpython.

in rhino_module: added draw ngon mesh in rhino

